### PR TITLE
Fixed Argument 2 passed to pocketmine\entity\Entity::createEntity() must be an instance of pocketmine\level\Level, null given

### DIFF
--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -990,7 +990,7 @@ class EventListener implements Listener
                 for ($i = 0; $i <= $enchantment->getLevel(); $i++) {
                     $tnt = Entity::createEntity("PrimedTNT", $entity->getLevel(), new CompoundTag("", ["Pos" => new ListTag("Pos", [new DoubleTag("", $entity->x), new DoubleTag("", $entity->y), new DoubleTag("", $entity->z)]), "Motion" => new ListTag("Motion", [new DoubleTag("", 0), new DoubleTag("", 0), new DoubleTag("", 0)]), "Rotation" => new ListTag("Rotation", [new FloatTag("", 0), new FloatTag("", 0)]), "Fuse" => new ByteTag("Fuse", 40)]));
                     $tnt->spawnToAll();
-                    $entity->close();
+                    $entity->flagForDespawn();
                 }
             }
         }


### PR DESCRIPTION
closing the entity doesn't return the level nor playing Hit Ground Sound
but Flagging for despawn does it

<!-- DO NOT REMOVE THIS:
failing to complete the required fields will result in the issue being closed due to insufficient information.
-->
Please make sure your pull request complies with these guidelines:
- * [x] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] Unless it is a minor code modification, you must use an IDE.
- * [x] Have a detailed title, like "Fix CustomEnchants::getName() must be..."

#### **What does the PR change?**
<!-- 
Does your Pull Request:
- resolve a bug? If so, link the issue with the PR and add explain what caused the issue.
- enhance the plugin? If so, explain what this adds, including why it should be added.
- translate the plugin? If so, refer to CONTRIBUTING.md for the guidelines of translating to another language.
-->
resolving https://github.com/DaPigGuy/PiggyCustomEnchants/issues/173

#### **Testing Environment**
<!-- PHP and OS version required, pmmp build link required. -->
- PHP: 7.2
- PMMP: 4.0.0+dev1225
- OS: Windows

#### **Extra Information**
<!-- Anything else we should know? -->
